### PR TITLE
Improvements to performance of accessing aggregate fields (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,25 @@ julia> e
 EnumStruct(e=<anonymous-enum>(0x00000007))
 ```
 
+CBinding.jl also allows you to apply an alignment strategy, such as `__packed__`, to an enumeration definition.
+An alignment strategy can be applied to both standalone enumeration types and enumerations nested within unions or structures.
+
+```jl
+julia> @cenum MyPackedNamedEnum {    # enum MyPackedNamedEnum {
+           PACKED_VALUE_1,           #     PACKED_VALUE_1,
+           PACKED_VALUE_2,           #     PACKED_VALUE_2,
+           PACKED_VALUE_3,           #     PACKED_VALUE_3
+       } __packed__                  # } __attribute__((packed));
+MyPackedNamedEnum
+
+julia> sizeof(MyNamedEnum)
+4
+
+julia> sizeof(MyPackedNamedEnum)
+1
+```
+
+
 ## C Bit Fields
 
 Specifying C bit fields is another feature provided by CBinding.jl.

--- a/README.md
+++ b/README.md
@@ -78,20 +78,20 @@ julia> zeroed
 MySecondCStruct(i=100, j=0, w=UInt8[0x00, 0x00, 0xff, 0x00], x=16711680, y=<anonymous-struct>[(c=0x00), (c=0x00), (c=0xff), (c=0x00)], z=MyFirstCStruct[(i=16711680)], m=MyFirstCStruct(i=0))
 ```
 
-When accessing a nested aggregate type, a `Caccessor` object is used to maintain a reference to the enclosing object.
+When accessing a nested aggregate (or array) type, a `Caccessor` object is used to maintain a reference to the enclosing object.
 To get the aggregate itself that a `Caccessor` is referring to you must use `[]` similar to Julia `Ref` usage.
 This will lead to some surprising results/behavior if you forget this detail.
 The implemented `Base.show` function will also cause the `Caccessor` to appear as if you are working with the aggregate, so trust `typeof`.
 
 ```jl
 julia> typeof(zeroed.m)
-Caccessor{MyFirstCStruct}
+CBinding.Caccessor{MyFirstCStruct,MySecondCStruct,Val{12}}
 
 julia> typeof(zeroed.m[])
 MyFirstCStruct
 
 julia> sizeof(zeroed.m)
-16
+8
 
 julia> sizeof(zeroed.m[])
 4

--- a/src/cenum.jl
+++ b/src/cenum.jl
@@ -123,13 +123,13 @@ _computeEnumType(::Type{CE}) where {CE<:Cenum} = eltype(CE)
 function _computeEnumType(::Type{AlignStrategy}, fields::Tuple) where {AlignStrategy}
 	(min, max) = extrema(map(last, fields))
 	
-	for typ in _enumTypes(AlignStrategy)
+	for typ in enumtypes(AlignStrategy)
 		typemin(typ) <= min && max <= typemax(typ) && return typ
 	end
 	
 	error("Unable to determine suitable enumeration storage type for the values provided")
 end
 
-_enumTypes(::Type{ALIGN_NATIVE}) = (UInt32, Int32, UInt64, Int64, UInt128, Int128)
-_enumTypes(::Type{ALIGN_PACKED}) = (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt128, Int128)
+enumtypes(::Type{ALIGN_NATIVE}) = (UInt32, Int32, UInt64, Int64, UInt128, Int128)
+enumtypes(::Type{ALIGN_PACKED}) = (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64, UInt128, Int128)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,6 +346,18 @@ include("layout-tests.jl")
 		@test bl.x.y == 0 && bl.x.z == 0
 		bl.x.z = 123
 		@test bl.x.y == 0 && bl.x.z == 123
+		
+		@cstruct ArrayOfStruct {
+			x::BrokenLayout[2]
+		}
+		@test sizeof(ArrayOfStruct) == 2*2*sizeof(Cint)
+		aos = ArrayOfStruct()
+		@test typeof(aos.x) <: CBinding.Caccessor
+		@test typeof(aos.x[]) <: Carray
+		@test typeof(aos.x[2]) <: CBinding.Caccessor
+		@test typeof(aos.x[2][]) <: BrokenLayout
+		@test typeof(aos.x[2].x) <: CBinding.Caccessor
+		@test typeof(aos.x[2].x.y) <: Cint
 	end
 	
 	

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,12 @@ function checkJL(expr, val)
 	types = Base.invokelatest(CBinding.propertytypes, x)
 	for (ind, prop) in enumerate(Base.invokelatest(propertynames, x))
 		x = Base.invokelatest(X.X)
-		Base.invokelatest(setproperty!, x, prop, sizeof(types[ind]) < sizeof(val) ? Core.Intrinsics.trunc_int(types[ind], val) : reinterpret(types[ind], val))
+		v1 = sizeof(types[ind]) < sizeof(val) ? Core.Intrinsics.trunc_int(types[ind], val) : reinterpret(types[ind], val)
+		Base.invokelatest(setproperty!, x, prop, v1)
+		v2 = Base.invokelatest(getproperty, x, prop)
+		Base.invokelatest(setproperty!, x, prop, v2)
+		v3 = Base.invokelatest(getproperty, x, prop)
+		@test v2 === v3
 		push!(result, "$(String(prop)): $(bytes2hex(UInt8[getfield(x, :mem)...,]))")
 	end
 	return result


### PR DESCRIPTION
Its not perfect, but a 25,000x improvement is acceptable.
For a simple test of accessing nested fields performance went from:
```
BenchmarkTools.Trial: 
  memory estimate:  2.95 KiB
  allocs estimate:  121
  --------------
  minimum time:     62.624 μs (0.00% GC)
  median time:      64.228 μs (0.00% GC)
  mean time:        67.337 μs (2.16% GC)
  maximum time:     14.649 ms (99.11% GC)
  --------------
  samples:          10000
  evals/sample:     1
```
to this:
```
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     2.774 ns (0.00% GC)
  median time:      2.779 ns (0.00% GC)
  mean time:        2.784 ns (0.00% GC)
  maximum time:     12.078 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```