### PR TITLE
Fix bug with self-referencing Cconst usage.

### DIFF
--- a/src/cbindings.jl
+++ b/src/cbindings.jl
@@ -23,7 +23,7 @@ function _cbindings(mod::Module, lib::String, block::Expr)
 	end
 	_addlibs(block)
 	
-	return esc(block)
+	return esc(Base.is_expr(block, :block) ? quote $(map(x -> x isa LineNumberNode ? x : :($(@__MODULE__).@eval $(x)), block.args)...) end : block)
 end
 
 

--- a/src/cconst.jl
+++ b/src/cconst.jl
@@ -2,7 +2,7 @@
 
 Cconst{T, S}(args...; kwargs...) where {T, S} = Cconst{T}(args...; kwargs...)
 Cconst{T}(args...; kwargs...) where {T} = Cconst(T(args...; kwargs...))
-Cconst(::Type{T}) where {T} = Cconst{nonconst(T), sizeof(nonconst(T))}
+Cconst(::Type{T}) where {T} = Cconst{nonconst(T)}
 Cconst(::Type{CA}) where {T, N, CA<:Carray{T, N}} = Carray(Cconst(nonconst(T)), Val(N))
 Cconst(x) = x
 Cconst(cc::Cconst) = cc

--- a/src/ctypelayout.jl
+++ b/src/ctypelayout.jl
@@ -112,6 +112,8 @@ struct Ctypefield
 	type::DataType  # field type
 	size::Int  # in bits:  0 means use sizeof(type)*8, >0 means bit field size
 	offset::Int  # in bits
+	
+	Ctypefield(ind, type, size, offset) = new(ind, (type <: Cconst ? Cconst(type){sizeof(nonconst(type))} : type), size, offset)
 end
 
 mutable struct Ctypelayout

--- a/test/cconst.jl
+++ b/test/cconst.jl
@@ -274,5 +274,11 @@
 	
 	@test f(x) == 0
 	@test @allocated(f(x)) == 0
+	
+	
+	@cstruct SelfRef {
+		ptr::Ptr{Cconst(SelfRef)}
+	}
+	@test sizeof(SelfRef) == sizeof(Ptr)
 end
 


### PR DESCRIPTION
Example of what didn't work:
```julia
@cstruct S {
    ptr::Ptr{Cconst(S)}
}
```
