### PR TITLE
Add Caccessor properties for Ptr{<:Caggregate}

### DIFF
--- a/src/caccessor.jl
+++ b/src/caccessor.jl
@@ -13,6 +13,13 @@ end
 Base.unsafe_wrap(::Type{FieldType}, ptr::Ptr) where {FieldType<:Union{Cdeferrable, Cconst{<:Cdeferrable}}} = Caccessor{FieldType}(reinterpret(Ptr{FieldType}, ptr))
 Base.unsafe_wrap(ptr::Ptr{FieldType}) where {FieldType<:Union{Cdeferrable, Cconst{<:Cdeferrable}}} = Caccessor{FieldType}(ptr)
 
+Base.propertynames(ptr::Ptr{CA}; kwargs...) where {CA<:Union{Caggregate, Cconst{<:Caggregate}}} = propertynames(CA; kwargs...)
+propertytypes(ptr::Ptr{CA}; kwargs...) where {CA<:Union{Caggregate, Cconst{<:Caggregate}}} = propertytypes(CA; kwargs...)
+Base.fieldnames(ptr::Ptr{CA}; kwargs...) where {CA<:Union{Caggregate, Cconst{<:Caggregate}}} = fieldnames(CA; kwargs...)
+
+Base.getproperty(ptr::Ptr{CA}, sym::Symbol) where {CA<:Union{Caggregate, Cconst{<:Caggregate}}} = getproperty(unsafe_wrap(ptr), sym)
+Base.setproperty!(ptr::Ptr{CA}, sym::Symbol, val) where {CA<:Caggregate} = setproperty!(unsafe_wrap(ptr), sym, val)
+
 Base.convert(::Type{T}, ca::Caccessor{T}) where {T} = ca[]
 Base.show(io::IO, ca::Caccessor) = show(io, ca[])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,5 +157,32 @@ include("layout-tests.jl")
 	include("cglobal.jl")
 	include("cfunction.jl")
 	include("cextern.jl")
+	
+	
+	@testset "Caccessor" begin
+		@cstruct AccessorInner {
+			i::Cint
+		}
+		
+		@cstruct AccessorOuter {
+			i::Cint
+			inner::AccessorInner
+			ptr::Ptr{AccessorInner}
+		}
+		
+		x = AccessorOuter(zero)
+		@test x.i == 0
+		@test x.inner.i == 0
+		@test x.ptr == C_NULL
+		
+		x.ptr = reinterpret(Ptr{AccessorInner}, pointer_from_objref(x))
+		@test x.ptr != C_NULL
+		@test x.ptr.i == 0
+		
+		x.i = 1234
+		@test x.i == 1234
+		@test x.inner.i == 0
+		@test x.ptr.i == 1234
+	end
 end
 


### PR DESCRIPTION
More elegantly lets users access nested aggregate type pointers.

Fixes #44