### PR TITLE
Add support for unnamed aggregate fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CBinding"
 uuid = "d43a6710-96b8-4a2d-833c-c424785e5374"
 authors = ["Keith Rutkowski <keith@analytech-solutions.com>"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
Apparently code like this has been observed in the wild:
```c
struct S {
    long: 32;
    long: 64;
};
```
