### PR TITLE
Add support for enum bitfields

### DIFF
--- a/src/ctypespec.jl
+++ b/src/ctypespec.jl
@@ -5,6 +5,7 @@ end
 
 Ctypespec(::Type{T}) where {T} = Tuple{T}
 Ctypespec(::Type{T}, ::Val{bits}) where {T, bits} = Tuple{T, bits}
+Ctypespec(::Type{CE}, ::Val{bits}) where {CE<:Cenum, bits} = Tuple{Ctypespec{concrete(CE), concrete(CE), strategy(CE), specification(CE)}, bits}
 Ctypespec(::Type{CO}) where {CO<:Copaques} = Ctypespec{concrete(CO), concrete(CO), strategy(CO), specification(CO)}
 
 Ctypespec(::Type{CO}, ::Type{S}, ::Type{TS}) where {CO<:Copaques, S, TS} = Ctypespec{CO, CO, S, TS}

--- a/test/cstruct.jl
+++ b/test/cstruct.jl
@@ -221,5 +221,22 @@
 	@test typeof(aos.x[2][]) <: BrokenLayout
 	@test typeof(aos.x[2].x) <: CBinding.Caccessor
 	@test typeof(aos.x[2].x.y) <: Cint
+	
+	@eval @cenum SmallEnum {
+		SMALL_1 = 1,
+		SMALL_2 = 2,
+		SMALL_3 = 4,
+	}
+	@eval @cstruct SmallEnumBitfield {
+		(a:8)::@cenum SmallEnum
+		(b:8)::@cenum SmallEnum
+	}
+	@test sizeof(SmallEnumBitfield) == sizeof(SmallEnum)
+	x = SmallEnumBitfield(zero)
+	@test getfield(x, :mem) == (0x00, 0x00, 0x00, 0x00)
+	x.a = SMALL_1
+	@test getfield(x, :mem) == (UInt8(SMALL_1), 0x00, 0x00, 0x00)
+	x.b = SMALL_3
+	@test getfield(x, :mem) == (UInt8(SMALL_1), UInt8(SMALL_3), 0x00, 0x00)
 end
 


### PR DESCRIPTION
Supports the following in C:
```c
enum E {
	E1 = 1,
	E2 = 2,
	E3 = 4
};

struct S {
	enum E a: 8;
	enum E b: 8;
	int c: 8;
};
```
in Julia:
```julia
@cenum E {
	E1 = 1,
	E2 = 2,
	E3 = 4,
};

@cstruct S {
	(a:8)::@cenum E
	(b:8)::@cenum E
	(c:8)::Cint
};
```
