### PR TITLE
Batch of bug fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1.5'
-          - '1.6-nightly'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CBinding"
 uuid = "d43a6710-96b8-4a2d-833c-c424785e5374"
 authors = ["Keith Rutkowski <keith@analytech-solutions.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ These kinds of situations can be handled with combinations of the following stri
 - `j` - provide additional bindings using Julian names (name collisions likely)
 - `J` - provide additional bindings using Julian names with annotated user-defined types (using `struct_`, `union_`, or `enum_` prefixes)
 - `m` - skip conversion of C macros
-- `n` - show warnings for macros or inline functions that are skipped
+- `n` - show warnings for macros or inline functions that are skipped (and other conversion issues)
 - `p` - mark the C code as "private" content that will not be exported
-- `q` - quietly parse the block of C code, suppressing any compiler messages
+- `q` - quietly parse the block of C code, suppressing any compiler/linker messages
 - `r` - the C code is only a reference to something in C-land and bindings are not to be generated
 - `s` - skip processing of this block of C code
 - `t` - skip conversion of C types

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -31,7 +31,8 @@ Base.eltype(::Type{CA}) where {T, N, CA<:Carrays{T, N}} = T
 Base.convert(::Type{CA}, t::Tuple) where {CA<:Carray} = CA(t...)
 
 Base.convert(::Type{CA}, str::String) where {T<:Union{Int8, UInt8, Cconst{Int8}, Cconst{UInt8}}, CA<:Carray{T}} = CA(str...)
-Base.String(ca::Carray{T}) where {T<:Union{Int8, UInt8, Cconst{Int8}, Cconst{UInt8}}} = String(map(t -> reinterpret(UInt8, convert(unqualifiedtype(T), t)), collect(ca)))
+Base.convert(::Type{String}, ca::Carray{T}) where {T<:Union{Int8, UInt8, Cconst{Int8}, Cconst{UInt8}}} = String(map(t -> reinterpret(UInt8, convert(unqualifiedtype(T), t)), collect(ca)))
+Base.String(ca::Carray{T}) where {T<:Union{Int8, UInt8, Cconst{Int8}, Cconst{UInt8}}} = convert(String, ca)
 Base.show(io::IO, ca::Carray{T}) where {T<:Union{Int8, UInt8, Cconst{Int8}, Cconst{UInt8}}} = show(io, String(ca))
 
 

--- a/src/comments.jl
+++ b/src/comments.jl
@@ -60,8 +60,14 @@ function Markdown.MD(ctx::Context, cursor::CXCursor, comment::CXComment)
 			cmd = _string(clang_BlockCommandComment_getCommandName, child)
 			if cmd == "brief" || cmd == "par" || cmd == "paragraph"
 				push!(contents, para)
-			elseif cmd == "note" || cmd == "warning" || cmd == "deprecated"
-				para = Markdown.Paragraph(["$(uppercase(cmd)):", para.content...])
+			elseif cmd == "bug" || cmd == "note" || cmd == "warning" || cmd == "deprecated" || cmd == "attention"
+				category =
+					cmd == "bug" ? "danger" :
+					cmd == "note" ? "info" :
+					cmd == "warning" ? "warning" :
+					cmd == "deprecated" ? "warning" :
+					cmd == "attention" ? "danger" : "info"
+				para = Markdown.Admonition("danger", titlecase(cmd), [para])
 				push!(contents, para)
 			elseif cmd == "sa" || cmd == "see"
 				para = isempty(para.content) ? para : Markdown.Paragraph("See also: [`$(strip(first(para.content)))`](@ref)")

--- a/src/comments.jl
+++ b/src/comments.jl
@@ -23,7 +23,7 @@ function Markdown.MD(ctx::Context, cursor::CXCursor)
 	
 	loc = getlocation(cursor)
 	if isnothing(loc)
-		loc = "Defined in the C Standard Library"
+		loc = "Defined by the parser/compiler"
 	else
 		loc = first(loc)
 		loc = loc.file == header(ctx) ? getblock(ctx, loc).loc : loc
@@ -40,7 +40,7 @@ function Markdown.MD(ctx::Context, cursor::CXCursor, comment::CXComment)
 	hasParams  = false
 	hasReturns = false
 	
-	contents = Markdown.MD(ctx, cursor).content
+	contents = []
 	for ind in 1:clang_Comment_getNumChildren(comment)
 		child = clang_Comment_getChild(comment, ind-1)
 		kind = clang_Comment_getKind(child)
@@ -115,7 +115,7 @@ function Markdown.MD(ctx::Context, cursor::CXCursor, comment::CXComment)
 		contents = contents[1:end-1]
 	end
 	
-	return Markdown.MD(contents)
+	return Markdown.MD([Markdown.MD(ctx, cursor).content..., contents...])
 end
 
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -42,9 +42,10 @@ end
 
 function getlib(ctx::Context, sym)
 	for (handle, lib) in ctx.libs
-		dlsym(handle, sym, throw_error = false) == C_NULL || return lib isa Symbol ? QuoteNode(lib) : lib
+		hdl = dlsym(handle, sym, throw_error = false)
+		isnothing(hdl) || hdl == C_NULL || return lib isa Symbol ? QuoteNode(lib) : lib
 	end
-	@warn "Failed to find `$(sym)` in any library: $(join(map(String, filter(x -> x isa Symbol, map(last, collect(ctx.libs)))), ", "))"
+	getblock(ctx).flags.quiet || @warn "Failed to find `$(sym)` in:\n"*join(map(((handle, lib),) -> "  $(lib isa Symbol ? lib : "or the Julia process")", collect(ctx.libs)), '\n')
 	return Nothing
 end
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -51,8 +51,12 @@ end
 
 
 function getcode(ctx::Context, cursor::CXCursor)
-	ismacro = cursor.kind == CXCursor_MacroDefinition
+	policy = clang_getCursorPrintingPolicy(cursor)
+	code = _string(clang_getCursorPrettyPrinted, cursor, policy)
+	isempty(code) || return code
 	
+	# if easy way didn't produce anything, we need to do it the messy way
+	ismacro = cursor.kind == CXCursor_MacroDefinition
 	tokens = tokenize(ctx.tu[], cursor)
 	tokens = ismacro ? tokens[2:end] : tokens
 	tokens = join(map(token -> clang_getTokenKind(token) == CXToken_Comment ? "" : string(ctx.tu[], token), tokens), ' ')

--- a/src/context.jl
+++ b/src/context.jl
@@ -51,6 +51,10 @@ end
 
 
 function getcode(ctx::Context, cursor::CXCursor)
+	# WARNING:  clang_getCursorPrettyPrinted has bugs:
+	# struct S22 {
+	# 	union { int i; float f; struct { int j; }; } (*(*f)(struct S22 x, int i))(int, float);
+	# };
 	policy = clang_getCursorPrintingPolicy(cursor)
 	if policy != C_NULL
 		code = _string(clang_getCursorPrettyPrinted, cursor, policy)

--- a/src/context.jl
+++ b/src/context.jl
@@ -16,9 +16,9 @@ getcontext(mod::Module) = get(CONTEXT_CACHE, mod, nothing)
 Base.close(ctx::Context) = delete!(CONTEXT_CACHE, ctx.mod)
 
 
-getjl(ctx::Context, args...; kwargs...) = getjl(typeof(ctx), args...; kwargs...)
+getjl(ctx::Context, args...; kwargs...) = getjl(typeof(ctx), args...; annotate = getblock(ctx).flags.annot, kwargs...)
 getjl(::Type{C}, str::String; kwargs...) where {C<:Context} = getjl(C, Symbol(str); kwargs...)
-getjl(::Type{C}, sym::Symbol) where {C<:Context} = esc(Symbol(replace(String(sym), r"^(struct|union|enum)\s+" => "")))
+getjl(::Type{C}, sym::Symbol; annotate::Bool = false) where {C<:Context} = esc(Symbol(replace(String(sym), r"^(struct|union|enum)\s+" => (annotate ? s"\1_" : ""))))
 
 getname(ctx::Context, args...; kwargs...) = getname(typeof(ctx), args...; kwargs...)
 getname(::Type{C}, str::String; kwargs...) where {C<:Context} = getname(C, Symbol(str); kwargs...)
@@ -447,7 +447,8 @@ function clang_str(mod::Module, loc::LineNumberNode, lang::Symbol, str::String, 
 		defer   = 'd' in opts,
 		nofunc  = 'f' in opts,
 		implic  = 'i' in opts,
-		jlsyms  = 'j' in opts,
+		jlsyms  = 'J' in opts || 'j' in opts,
+		annot   = 'J' in opts,
 		nomacro = 'm' in opts,
 		notify  = 'n' in opts,
 		priv    = 'p' in opts,

--- a/src/context_c.jl
+++ b/src/context_c.jl
@@ -649,13 +649,13 @@ function getexprs_binding(ctx::Context{:c}, cursor::CXCursor)
 		push!(ctx.bindings, binding)
 		binding = esc(binding)
 		
-		lib = getlib(ctx, name)
 		jlsym = getjl(ctx, name)
 		sym = gettype(ctx, name)
 		docs = getdocs(ctx, cursor)
 		
 		type = clang_getCursorType(cursor)
 		if cursor.kind == CXCursor_VarDecl
+			lib = getlib(ctx, name)
 			append!(exprs, getexprs(ctx, ((sym, jlsym, docs),),
 				:(struct $(binding){$(getjl(ctx, :name))} <: Cbinding{$(gettype(ctx, type)), $(QuoteNode(Symbol(lib))), $(QuoteNode(Symbol(name)))} end),
 				:(const $(sym) = $(binding){$(QuoteNode(Symbol(name)))}()),
@@ -681,6 +681,8 @@ function getexprs_binding(ctx::Context{:c}, cursor::CXCursor)
 				push!(exprs,
 					:(include_dependency($(String(lib.value)))),
 				)
+			else
+				lib = getlib(ctx, name)
 			end
 			
 			rettype = clang_getResultType(type)

--- a/src/context_c.jl
+++ b/src/context_c.jl
@@ -667,7 +667,7 @@ function getexprs_binding(ctx::Context{:c}, cursor::CXCursor)
 				code = replace(code, r"(^|\s)inline\s" => s"\1")
 				code = replace(code, r"(^|\s)static\s" => s"\1")
 				code = replace(code, r"(^|\s)extern\s" => s"\1")
-				code = replace(code, " $(name)(" => " $(unname)(")
+				code = replace(code, r"(\W)"*name*"(" => SubstitutionString("\\1$(unname)("))
 				code = "$(lstrip(code)) __attribute__((alias($(repr(name)))));"
 				push!(getblock(ctx).inlines, code)
 				

--- a/src/context_c.jl
+++ b/src/context_c.jl
@@ -172,6 +172,8 @@ function getbuiltintype(ctx::Type{Context{:c}}, k::CXTypeKind, n::String, s::Int
 		result = :(Clong)
 	elseif k == CXType_LongLong
 		result = :(Clonglong)
+	elseif k == CXType_Bool && s == sizeof(Bool)
+		result = :(Bool)
 	elseif k in (
 		CXType_Char_U,
 		CXType_UChar,
@@ -191,6 +193,8 @@ function getbuiltintype(ctx::Type{Context{:c}}, k::CXTypeKind, n::String, s::Int
 		result = :(Cdouble)
 	elseif k == CXType_LongDouble
 		result = :(Clongdouble)
+	elseif k == CXType_WChar
+		result = :(Cwchar_t)
 	else
 		# create correct size and alignment to mimic the type
 		(a in (1, 2, 4, 8, 16) && (s÷a)*a == s) || error("Unhandled sizeof ($(s)) or alignof ($(a)) for compiler built-in `$(n)`")
@@ -227,6 +231,7 @@ function gettype(ctx::Type{Context{:c}}, type::CXType; kwargs...)
 		CXType_Long, CXType_ULong,
 		CXType_LongLong, CXType_ULongLong,
 		CXType_Float, CXType_Double, CXType_LongDouble,
+		CXType_WChar,
 	)
 		result = getbuiltintype(ctx, type)
 	elseif @isdefined(CXType_Atomic) && type.kind == CXType_Atomic  # libclang 9 lacks atomic

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -65,7 +65,7 @@ end
 
 
 Base.cconvert(::Type{Cptr{CF}}, func::Function) where {retT, argTs, CF<:Cfunction{retT, argTs}} = Cptr{CF}(func)
-Base.cconvert(::Type{Cptr{CF}}, func::Base.CFunction) where {retT, argTs, CF<:Cfunction{retT, argTs}} = Cptr{CF}(Base.unsafe_convert(Ptr{Cvoid}(func)))
+Base.cconvert(::Type{Cptr{CF}}, func::Base.CFunction) where {retT, argTs, CF<:Cfunction{retT, argTs}} = Cptr{CF}(Base.unsafe_convert(Ptr{Cvoid}, func))
 
 
 Cptr{CF}(func::Function) where {CF<:Cfunction} = funccallback(CF, Val(func))

--- a/src/libclang.jl
+++ b/src/libclang.jl
@@ -38,7 +38,6 @@ end
 
 Base.string(cursor::CXType) = _string(clang_getTypeSpelling, cursor)
 Base.string(cursor::CXCursor) = _string(clang_getCursorSpelling, cursor)
-Base.string(diag::CXDiagnostic) = _string(clang_formatDiagnostic, diag, clang_defaultDiagnosticDisplayOptions())
 Base.string(tu::CXTranslationUnit, token::CXToken) = _string(clang_getTokenSpelling, tu, token)
 
 

--- a/src/libclang.jl
+++ b/src/libclang.jl
@@ -1,6 +1,6 @@
 
 
-# deps/jl needs these to be available
+# deps/libclang-*.jl needs these to be available
 libclang_path() = libclang.Clang_jll.libclang_path
 libclang_version() = libclang_version(libclang_path())
 function libclang_version(path::String)

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -101,6 +101,16 @@
 	@test ula.str[5][] == 5
 	
 	Libc.free(ptr)
+	
+	# https://github.com/analytech-solutions/CBinding.jl/issues/66
+	@eval c"""
+	struct file_format {
+		unsigned char Header[2000];
+	};
+	"""
+	x = c"struct file_format"(Header = "test")
+	@test x.Header[2] == Int('e')
+	@test x.Header[2000] == 0
 end
 
 

--- a/test/includes.jl
+++ b/test/includes.jl
@@ -11,7 +11,7 @@
 	@test length(ctx.hdrs) == 1
 	@eval c"""
 	#include "test.h"
-	"""iu
+	"""iuq
 	@test length(ctx.hdrs) == 1
 	@eval c"""
 	#include <inttypes.h>

--- a/test/includes.jl
+++ b/test/includes.jl
@@ -7,15 +7,15 @@
 	@test length(ctx.hdrs) == 0
 	@eval c"""
 	#include <stddef.h>
-	"""
+	"""u
 	@test length(ctx.hdrs) == 1
 	@eval c"""
 	#include "test.h"
-	"""i
+	"""iu
 	@test length(ctx.hdrs) == 1
 	@eval c"""
 	#include <inttypes.h>
-	"""s
+	"""su
 	@test length(ctx.hdrs) == 0
 	
 	str = String(take!(ctx.src))


### PR DESCRIPTION
Fix `Ref`/`Cptr` conversion, `Base.CFunction`, missing warning messages, missing builtin types, inline function conversion, comment conversion, and  large user-defined type access bugs.

fixes #66